### PR TITLE
PoC implementation of a wildcard directories lookup feature

### DIFF
--- a/bin/canned
+++ b/bin/canned
@@ -7,6 +7,9 @@ var canned = require('../canned')
           .default('p', 3000)
           .alias('p', 'port')
           .describe('p', 'server port')
+          .default('w', 'any')
+          .alias('w', 'wildcard')
+          .describe('w', 'wildcard path name for ids')
           .default('cors', true)
           .describe('cors', 'disable cors support')
           .default('headers', false)
@@ -28,6 +31,7 @@ var dir = ''
 ,   cors_headers = argv.headers
 ,   logger
 ,   cannedDir
+,   wildcard = argv.wildcard
 
 if (argv._.length === 1) dir = argv._[0] // use the passed directory
 if (argv.q) {
@@ -38,6 +42,6 @@ if (argv.q) {
   process.stdout.write('starting canned on port ' + port + ' for ' + cannedDir + '\n')
 }
 
-var can = canned(dir, { logger: logger, cors: cors, cors_headers: cors_headers})
+var can = canned(dir, { logger: logger, cors: cors, cors_headers: cors_headers, wildcard: wildcard})
 http.createServer(can).listen(port)
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,3 +28,68 @@ utils.removeSpecialComments = function (data) {
   }).join("\n").trim()
 }
 
+/***
+ * Given a path and a wildcard string, return a list of paths
+ * with every combination possible resulting from t he replacement of
+ * any integer id found in the path with the wildcard string.
+ *
+ * The resulting list of paths is ordered by more "specific" to more
+ * "generic" paths, for example using a wildcard of 'any' for the path:
+ *
+ *     api/2/customer/123/invoice/321/
+ *
+ * will return:
+ *
+ * [
+ *   '/api/2/customer/123/invoice/321/',
+ *   '/api/2/customer/123/invoice/any/',
+ *   '/api/2/customer/any/invoice/321/',
+ *   '/api/2/customer/any/invoice/any/',
+ *   '/api/any/customer/123/invoice/321/',
+ *   '/api/any/customer/123/invoice/any/',
+ *   '/api/any/customer/any/invoice/321/',
+ *   '/api/any/customer/any/invoice/any/'
+ * ]
+ *
+ * @param path - the original path
+ * @param wildcard - the replacmeent string
+ * @returns {Array} - the resulting combination, ordered by specificity
+ */
+
+utils.generatePaths = function (path, wildcard) {
+  // Split the path and calculate how many paths will be generated
+  var parts = path.split('/');
+  var matches = path.match(/\/\d+(\/|$)/gi);
+  var lookPathsParts = [];
+
+  // Locate replaceable parts indexes
+  var matchesIndexes = [];
+  parts.forEach(function (p, i) {
+    if (p.match(/^\d+$/)) {
+      matchesIndexes.push(i);
+    }
+  });
+
+  // Copy the original parts as a starting point for the new parts
+  for (var i = 0; i < Math.pow(2, matches.length); i++) {
+    lookPathsParts.push(parts.slice());
+  }
+
+  // Generate the new paths parts
+  for (var i = matches.length; i > 0; --i) {
+    var skip = Math.pow(2, i) / 2;
+    var replacePartIndex = matches.length - i;
+    for (var j = skip; j < lookPathsParts.length; j += (skip * 2)) {
+      for (var k = 0; k < skip; k++) {
+        lookPathsParts[j + k][matchesIndexes[replacePartIndex]] = wildcard;
+      }
+    }
+  }
+
+  // Build the final path strings
+  var lookPaths = [];
+  lookPathsParts.forEach(function (p) {
+    lookPaths.push(p.join('/'));
+  });
+  return lookPaths;
+}


### PR DESCRIPTION
given a request like: 
   
    GET /api/2/customer/123/invoice/321/

The following paths will be looked up:

    canned/api/2/customer/123/invoice/321/index.any.json
    canned/api/2/customer/123/invoice/any/index.any.json
    canned/api/2/customer/any/invoice/321/index.any.json
    canned/api/2/customer/any/invoice/any/index.any.json
    canned/api/any/customer/123/invoice/321/index.any.json
    canned/api/any/customer/123/invoice/any/index.any.json
    canned/api/any/customer/any/invoice/321/index.any.json
    canned/api/any/customer/any/invoice/any/index.any.json